### PR TITLE
Add AVS2-MP3 test sample

### DIFF
--- a/test_files/test9-tag.xml
+++ b/test_files/test9-tag.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!DOCTYPE Tags SYSTEM "matroskatags.dtd">
+<Tags>
+  <!-- movie -->
+  <Tag>
+    <Targets>
+      <TargetTypeValue>50</TargetTypeValue>
+    </Targets>
+    <Simple>
+      <Name>TITLE</Name>
+      <String>Big Buck Bunny - test 9</String>
+    </Simple>
+    <Simple>
+      <Name>DATE_RELEASED</Name>
+      <String>2010</String>
+    </Simple>
+    <Simple>
+      <Name>COMMENT</Name>
+      <String>Matroska test File 9, for testing AVS2 coding format. Codecs are AVS2-P2 and MP3</String>
+    </Simple>
+  </Tag>
+</Tags>


### PR DESCRIPTION
This is a test sample made myself with codec AVS2 and MP3 (using xAVS2 for video). This sample came from test 1 and was remade by ffmpeg though command `/ffmpeg -c:v libdavs2 -i test1.avs2 -i test1.mp3 -c:v copy -c:a copy ttest9.mkv`. Actually I'm still learning about mkv format and could not get much info from [ffmpeg documentation of matroska](https://ffmpeg.org/ffmpeg-formats.html#matroska) (especially about the tags). So, I'm not sure whether this sample is well or not.